### PR TITLE
Rename instances of SCM to Repo

### DIFF
--- a/baleen/action/__init__.py
+++ b/baleen/action/__init__.py
@@ -274,7 +274,7 @@ class DockerActionPlan(ActionPlan):
         Check if all project dependencies have a valid build.
         """
         try:
-            p = Project.objects.get(scm_url=repo)
+            p = Project.objects.get(repo_url=repo)
         except Project.DoesNotExist:
             return False
         j = p.last_successful_job()

--- a/baleen/action/project.py
+++ b/baleen/action/project.py
@@ -68,7 +68,7 @@ class GitAction(Action):
 
     def clone_repo(self, p):
         git = subprocess.Popen(
-            ["git", "clone", p.scm_url, p.project_dir],
+            ["git", "clone", p.repo_url, p.project_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
             )

--- a/baleen/project/forms.py
+++ b/baleen/project/forms.py
@@ -16,4 +16,4 @@ class ProjectForm(forms.ModelForm):
 
     class Meta:
         model = Project
-        fields = ['name', 'site_url', 'scm_url', 'branch']
+        fields = ['name', 'site_url', 'repo_url', 'branch']

--- a/baleen/project/models.py
+++ b/baleen/project/models.py
@@ -26,11 +26,11 @@ class Project(models.Model):
             verbose_name="Site URL",
             help_text='A URL to where this project deploys to')
 
-    scm_url = models.CharField(max_length=255, null=True, blank=True,
-            verbose_name="SCM Repostory URL",
+    repo_url = models.CharField(max_length=255, null=True, blank=True,
+            verbose_name="Repository URL",
             help_text='URL to git repo')
-    #scm_sync_success = models.BooleanField(default=False, editable=False,
-            #help_text='Was the last attempt to sync with the SCM successful?')
+    #repo_sync_success = models.BooleanField(default=False, editable=False,
+            #help_text='Was the last attempt to sync with the repo successful?')
     creator = models.ForeignKey('auth.User', null=True)
 
     github_token = models.CharField(max_length=255, editable=False,
@@ -52,7 +52,7 @@ class Project(models.Model):
 
     def __init__(self, *args, **kwargs):
         super(Project, self).__init__(*args, **kwargs)
-        self._original_scm_url = self.scm_url
+        self._original_repo_url = self.repo_url
 
     def __unicode__(self):
         return "Project %s" % self.name
@@ -77,8 +77,8 @@ class Project(models.Model):
             cred_name = 'deploykey_' + self.name
             self.private_key, self.public_key = get_credential_key_pair(cred_name, self)
 
-        if self._original_scm_url != self.scm_url:
-            # The revision control url changed, we need to fire a task to
+        if self._original_repo_url != self.repo_url:
+            # The repo url changed, we need to fire a task to
             # checkout the code and configure based on the baleen.yml
             # (unless manual_config=True)
             do_clone = True


### PR DESCRIPTION
This changes the model, so it'll require a DB drop/migration.