### PR TITLE
Add build option to worker command

### DIFF
--- a/baleen/action/__init__.py
+++ b/baleen/action/__init__.py
@@ -232,17 +232,22 @@ class DockerActionPlan(ActionPlan):
         # try and deal to the dependencies first, while creating a post-success
         # hook waiting for them all.
 
-        plan.append({
-                   'group': 'docker',
-                   'action': 'test_with_fig',
-                   'name': 'Test with fig',
-                   'index': index,
-                   'fig_data': build_data.get('test'), #'fig_test.yml',
-                   'project': self.project.name,
-                })
-        index += 1
+        if build_data.get('test'):
+            plan.append({
+                       'group': 'docker',
+                       'action': 'test_with_fig',
+                       'name': 'Test with fig',
+                       'index': index,
+                       'fig_data': build_data.get('test'), #'fig_test.yml',
+                       'project': self.project.name,
+                    })
+            index += 1
 
-        for artifact_type, details in build_data.get('artifacts', {}).items():
+        for artifact_type, location in build_data.get('artifacts', {}).items():
+            if build_data.get('test'):
+                # TODO support doing a null run of a container and extracting
+                # artifacts from just the build process
+                raise Exception("artifacts key specified but no test!")
             plan.append({
                        'group': 'docker',
                        'action': 'get_build_artifact',
@@ -250,7 +255,7 @@ class DockerActionPlan(ActionPlan):
                        'name': 'Get build artifact ' + artifact_type,
                        'index': index + 1,
                        'artifact_type': artifact_type,
-                       'path': details.get('path')
+                       'location': location
                     })
             index += 1
 

--- a/baleen/action/__init__.py
+++ b/baleen/action/__init__.py
@@ -37,6 +37,9 @@ class Action(object):
     def __unicode__(self):
         return "Action: %s" % self.name
 
+    def __str__(self):
+        return self.__unicode__()
+
     def send_event_hooks(self, status):
         event = {
             'type': 'action',
@@ -45,7 +48,6 @@ class Action(object):
         }
         gearman_client = gearman.GearmanClient([settings.GEARMAN_SERVER])
         gearman_client.submit_job(settings.GEARMAN_JOB_LABEL, json.dumps({'event': event}), background=True)
-
     
     @property
     def statsd_name(self):

--- a/baleen/action/docker.py
+++ b/baleen/action/docker.py
@@ -15,7 +15,6 @@ from baleen.artifact.models import XUnitOutput, CoverageXMLOutput, CoverageHTMLO
 
 log = logging.getLogger('baleen.action.docker')
 
-
 def login_registry(registry, creds):
     """
     Make sure we have logged into a registry using the 
@@ -38,6 +37,7 @@ def login_registry(registry, creds):
 
     stdout = stdoutdata.decode('utf-8')
     stderr = stderrdata.decode('utf-8')
+
     return {
         'stdout': stdout,
         'stderr': stderr,
@@ -126,24 +126,22 @@ class TestWithFigAction(Action):
         self.fig_data = yaml.load(StringIO(self.fig_raw_data))
         self.volume_dir = None
 
-    def _inject_baleen_data(self, data):
+    def _inject_baleen_data(self, data, credentials, stash):
         from baleen.project.models import Credential
-
-        build_data = yaml.load(StringIO(self.job.build_definition))
 
         for container in data.keys():
             if 'image' in data[container]:
                 image = data[container]['image']
             else:
-                image = self.job.stash['docker_image']
+                image = stash['docker_image']
             image_parts = image.rsplit(':')
             if len(image_parts) > 1:
                 image = image_parts[0] 
-            data[container]['image'] = image + ':' + self.job.stash['docker_tag']
+            data[container]['image'] = image + ':' + stash['docker_tag']
 
-            if 'credentials' in build_data:
+            if credentials:
                 data[container].setdefault('environment', {})
-                for c_name, value in build_data['credentials'].items():
+                for c_name, value in credentials.items():
                     try:
                         c = Credential.objects.get(project=self.project, name=c_name)
                         val = c.value
@@ -169,7 +167,12 @@ class TestWithFigAction(Action):
         return identity_fn
 
     def execute(self, stdoutlog, stderrlog, action_result):
-        fig_data_with_images = self._inject_baleen_data(self.fig_data)
+        build_data = yaml.load(StringIO(self.job.build_definition))
+
+        fig_data_with_images = self._inject_baleen_data(self.fig_data,
+                build_data.get('credentials'),
+                self.job.stash
+                )
         # Set the FIG_PROJECT_NAME environment variable to build id
         # to avoid concurrent builds getting funky:
         # https://github.com/docker/fig/issues/748
@@ -264,7 +267,7 @@ class GetBuildArtifactAction(Action):
 
     def __init__(self, project, name, index, *arg, **kwarg):
         super(GetBuildArtifactAction, self).__init__(project, name, index)
-        self.artifact_path = kwarg.get('path')
+        self.artifact_path = kwarg.get('location', {}).get('path')
         self.artifact_type = kwarg.get('artifact_type')
 
     def __unicode__(self):

--- a/baleen/action/docker.py
+++ b/baleen/action/docker.py
@@ -289,8 +289,8 @@ class GetBuildArtifactAction(Action):
 
         stdout = stdout.decode('utf-8')
         stderr = stderr.decode('utf-8')
-        log.debug(str(self) + 'stdout: %s' % stdout)
-        log.debug(str(self) + 'stderr: %s' % stderr)
+        log.debug(str(self) + ' stdout: %s' % stdout)
+        log.debug(str(self) + ' stderr: %s' % stderr)
 
         if status == 0:
             self.record_artifact(

--- a/baleen/action/docker.py
+++ b/baleen/action/docker.py
@@ -1,7 +1,6 @@
 import subprocess
 import logging
 import os
-import sys
 import yaml
 import tempfile
 
@@ -75,7 +74,7 @@ class BuildImageAction(Action):
         self.job.stash['docker_image'] = self.image_name
         self.job.stash['docker_tag'] = self.docker_tag
 
-        path = os.path.join(settings.BUILD_ROOT, self.project.project_dir)
+        path = self.job.job_dirs["build"]
         with cd(path):
             docker = subprocess.Popen(
                 ["docker", "build", "-t",
@@ -273,11 +272,7 @@ class GetBuildArtifactAction(Action):
 
     def execute(self, stdoutlog, stderrlog, action_result):
         CONTAINER_NAME = self.job.stash['fig_test_container']
-        path = os.path.join(
-                settings.ARTIFACT_DIR,
-                self.project.project_dir,
-                str(self.job.id)
-                )
+        path = self.job.job_dirs['artifact']
         mkdir_p(path)
 
         docker = subprocess.Popen(
@@ -334,7 +329,7 @@ class TagGoodImageAction(Action):
         return "TagGoodImageAction: %s" % self.name
 
     def execute(self, stdoutlog, stderrlog, action_result):
-        path = os.path.join(settings.BUILD_ROOT, self.project.project_dir)
+        path = self.job.job_dirs['build']
         with cd(path):
             docker = subprocess.Popen(
                 ["docker", "tag",

--- a/baleen/action/project.py
+++ b/baleen/action/project.py
@@ -1,7 +1,6 @@
 import stat
 import logging
 import os
-import sys
 import shutil
 import subprocess
 import tempfile

--- a/baleen/job/management/commands/worker.py
+++ b/baleen/job/management/commands/worker.py
@@ -13,8 +13,9 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from baleen.job.models import Job
-from baleen.project.models import ActionResult
+from baleen.project.models import ActionResult, Project
 from baleen.action.dispatch import get_action_object
+from baleen.utils import mkdir_p, cd
 
 import statsd
 from statsd.counter import Counter
@@ -61,11 +62,11 @@ class Command(BaseCommand):
                 dest='clear_jobs',
                 help="Clear all jobs in queue, don't run them."
             ),
-            make_option('-r', '--raw-plan',
+            make_option('-b', '--build',
                 default=None,
                 action='store',
-                dest='raw_plan',
-                help="Take a json file as the action plan, run it and exit"
+                dest='build',
+                help="Take a directory with a baleen.yml and build it."
             ),
         )
 
@@ -113,7 +114,7 @@ class Command(BaseCommand):
             self._reset_jobs()
         return ''
 
-    def _do_action(self, job, action, project_timer):
+    def _do_action(self, job, action, project_timer=None):
         # record this process id so that we can kill it via the web interface
         # supervisord will automatically create a replacement process.
 
@@ -128,7 +129,8 @@ class Command(BaseCommand):
             # If we got a non-zero exit status, then don't run any more actions
             raise Exception('Non-zero exit code')
 
-        project_timer.intermediate(a.statsd_name)
+        if project_timer:
+            project_timer.intermediate(a.statsd_name)
         print "Action success."
 
 
@@ -183,11 +185,6 @@ class Command(BaseCommand):
         # no-one would see the response anyway
         return ''
 
-    def process_plan(self, plan):
-        for step in plan:
-            action = get_action_object(step)
-            action.run()
-
     def handle(self, *args, **options):
         self.current_gearman_job = None
         self.current_baleen_job = None
@@ -195,19 +192,18 @@ class Command(BaseCommand):
 
         self.worker_process_number = options['worker_number']
 
-        if options['raw_plan']:
-            with open(options['raw_plan']) as f:
-                plan_data = json.load(f)
-            self.process_plan(plan_data)
+        signal(SIGTERM, self.clean_up)
+        signal(SIGINT, self.clean_up)
+
+        if options['build']:
+            self.build(options['build'])
+            sys.exit(0)
         elif options['clear_jobs']:
             print "Removing all jobs in queue..."
             gearman_worker.register_task(settings.GEARMAN_JOB_LABEL, functools.partial(self.clear_job))
         else:
             # Default is to wait for jobs
             gearman_worker.register_task(settings.GEARMAN_JOB_LABEL, functools.partial(self.run_task))
-
-        signal(SIGTERM, self.clean_up)
-        signal(SIGINT, self.clean_up)
 
         print "baleen worker reporting for duty, sir/m'am!"
         gearman_worker.work()
@@ -216,6 +212,57 @@ class Command(BaseCommand):
         job_id = json.loads(gm_job.data).get('job_id', None)
         result = "Clearing job for job_id %d" % str(job_id)
         return result
+
+    def build(self, build_dir):
+        project_name = os.path.basename(build_dir)
+        p = Project(name=project_name)
+        p.save()
+        job = Job(project=p, manual_by=p.creator)
+        job.save()
+
+        self.current_baleen_job = job
+
+        try:
+            job._job_dirs = {
+                    'build': build_dir,
+                    'artifact': os.path.join('/tmp/', project_name),
+                    'logs': os.path.join('/tmp/', project_name),
+                    'checkout': None
+                    }
+            job.record_start(os.getpid())
+
+            # import baleen file
+            import_action_spec = {
+                   'group': 'project',
+                   'action': 'import_build_definition',
+                   'name': 'Import build definition for project %s' % p.name,
+                   'index': 1,
+                   'project': p.name
+                }
+            self._do_action(job, import_action_spec)
+
+            actions = job.project.action_plan()
+            for action in actions:
+                self._do_action(job, action)
+
+            job.record_done()
+            self._reset_jobs()
+
+            print "Job completed."
+            # Return empty string since this is always invoked in background mode, so
+            # no-one would see the response anyway
+            return ''
+        except Exception, e:
+            msg = "Unexpected error:" + str(sys.exc_info()[0])
+            msg += str(e)
+            print msg
+            traceback.print_tb(sys.exc_info()[2])
+
+            self.clear_current_action(msg)
+            self._reset_jobs()
+
+        p.delete()
+
 
     def clear_current_action(self, msg=None):
         if self.current_action:
@@ -230,7 +277,7 @@ class Command(BaseCommand):
                 })
             except ActionResult.DoesNotExist:
                 self.current_baleen_job.record_done(success=False)
-        else:
+        elif self.current_baleen_job:
             print "no action, just done"
             self.current_baleen_job.record_done(success=False)
 

--- a/baleen/job/management/commands/worker.py
+++ b/baleen/job/management/commands/worker.py
@@ -214,8 +214,18 @@ class Command(BaseCommand):
         return result
 
     def build(self, build_dir):
-        project_name = os.path.basename(build_dir)
-        p = Project(name=project_name)
+        p = None
+        project_name = None
+        counter = 1
+        while p is None:
+            project_name = os.path.basename(build_dir) + str(counter)
+            try:
+                Project.objects.get(name=project_name)
+                counter += 1
+            except Project.DoesNotExist:
+                p = Project(name=project_name)
+            if counter > 100:
+                raise Exception("Can't find a free project name.")
         p.save()
         job = Job(project=p, manual_by=p.creator)
         job.save()
@@ -249,9 +259,6 @@ class Command(BaseCommand):
             self._reset_jobs()
 
             print "Job completed."
-            # Return empty string since this is always invoked in background mode, so
-            # no-one would see the response anyway
-            return ''
         except Exception, e:
             msg = "Unexpected error:" + str(sys.exc_info()[0])
             msg += str(e)

--- a/baleen/job/management/commands/worker.py
+++ b/baleen/job/management/commands/worker.py
@@ -262,7 +262,7 @@ class Command(BaseCommand):
         except Exception, e:
             msg = "Unexpected error:" + str(sys.exc_info()[0])
             msg += str(e)
-            print msg
+            print(msg)
             traceback.print_tb(sys.exc_info()[2])
 
             self.clear_current_action(msg)
@@ -273,7 +273,6 @@ class Command(BaseCommand):
 
     def clear_current_action(self, msg=None):
         if self.current_action:
-            print "have action, record action response"
             if msg is None:
                 msg = "Action was interrupted by kill/term signal."
 
@@ -285,7 +284,6 @@ class Command(BaseCommand):
             except ActionResult.DoesNotExist:
                 self.current_baleen_job.record_done(success=False)
         elif self.current_baleen_job:
-            print "no action, just done"
             self.current_baleen_job.record_done(success=False)
 
     def clean_up(self, *args):

--- a/baleen/project/tests.py
+++ b/baleen/project/tests.py
@@ -32,8 +32,10 @@ class ProjectTest(TestCase):
 
     @patch('gearman.GearmanClient')
     def test_github_hook(self, gearman):
-        data = {'payload': json.dumps({'commits': []})}
-        response = self.client.post(reverse('github_url', kwargs={'github_token': self.project.github_token}), data=data)
+        data = {'commits': [], 'ref': "refs/heads/master"}
+        response = self.client.post(reverse('github_url', kwargs={'github_token': self.project.github_token}),
+                json.dumps(data),
+                content_type="application/json")
         self.assertContains(response, 'processed')
 
 


### PR DESCRIPTION
Allows people to build on the command line from an already checked out project with a `baleen.yml`.

Closes #16 